### PR TITLE
Pipe's props is initialized with blank hashmap. makes getProps() never return null

### DIFF
--- a/client/src/main/java/zingg/client/pipe/Pipe.java
+++ b/client/src/main/java/zingg/client/pipe/Pipe.java
@@ -32,7 +32,7 @@ public class Pipe implements Serializable{
 	String name;
 	Format format;
 	String preprocessors;
-	Map<String, String> props;
+	Map<String, String> props = new HashMap<String, String>();
 	@JsonSerialize(using = CustomSchemaSerializer.class)
 	StructType schema = null;
 	Map<String, String> sparkProps;

--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -202,7 +202,7 @@ public class Labeller extends ZinggBase {
 		System.out.println(msg);
 	}
 
-	protected void writeLabelledOutput(Dataset<Row> records) {
+	protected void writeLabelledOutput(Dataset<Row> records) throws ZinggClientException {
 		if (records == null) {
 			LOG.warn("No records to be labelled.");
 			return;

--- a/core/src/main/java/zingg/Linker.java
+++ b/core/src/main/java/zingg/Linker.java
@@ -50,7 +50,7 @@ public class Linker extends Matcher {
 		return blocked;
 	}
 
-	public void writeOutput(Dataset<Row> sampleOrginal, Dataset<Row> dupes) {
+	public void writeOutput(Dataset<Row> sampleOrginal, Dataset<Row> dupes) throws ZinggClientException {
 		try {
 			// input dupes are pairs
 			/// pick ones according to the threshold by user

--- a/core/src/main/java/zingg/Matcher.java
+++ b/core/src/main/java/zingg/Matcher.java
@@ -159,7 +159,7 @@ public class Matcher extends ZinggBase{
 		}
     }
 
-	public void writeOutput(Dataset<Row> blocked, Dataset<Row> dupesActual) {
+	public void writeOutput(Dataset<Row> blocked, Dataset<Row> dupesActual) throws ZinggClientException {
 		try{
 		//input dupes are pairs
 		///pick ones according to the threshold by user

--- a/core/src/main/java/zingg/TrainingDataFinder.java
+++ b/core/src/main/java/zingg/TrainingDataFinder.java
@@ -138,7 +138,7 @@ public class TrainingDataFinder extends ZinggBase{
 			}	
     }
 
-	public void writeUncertain(Dataset<Row> dupesActual, Dataset<Row> sampleOrginal) {
+	public void writeUncertain(Dataset<Row> dupesActual, Dataset<Row> sampleOrginal) throws ZinggClientException {
 		//dupesActual.show(4);
 		//input dupes are pairs
 		dupesActual = DFUtil.addClusterRowNumber(dupesActual, spark);

--- a/core/src/main/java/zingg/util/BlockingTreeUtil.java
+++ b/core/src/main/java/zingg/util/BlockingTreeUtil.java
@@ -77,7 +77,7 @@ public class BlockingTreeUtil {
 		return createBlockingTree(sample, positives, sampleFraction, blockSize, args, hashFunctions);
 	}
 	
-	public static void writeBlockingTree(SparkSession spark, JavaSparkContext ctx, Tree<Canopy> blockingTree, Arguments args) throws Exception {
+	public static void writeBlockingTree(SparkSession spark, JavaSparkContext ctx, Tree<Canopy> blockingTree, Arguments args) throws Exception, ZinggClientException {
 		byte[] byteArray  = Util.convertObjectIntoByteArray(blockingTree);
 		StructType schema = DataTypes.createStructType(new StructField[] { DataTypes.createStructField("BlockingTree", DataTypes.BinaryType, false) });
 		List<Object> objList = new ArrayList<>();

--- a/core/src/main/java/zingg/util/PipeUtil.java
+++ b/core/src/main/java/zingg/util/PipeUtil.java
@@ -184,7 +184,8 @@ public class PipeUtil {
 		return rows;
 	}
 
-	public static void write(Dataset<Row> toWriteOrig, Arguments args, JavaSparkContext ctx, Pipe... pipes) {
+	public static void write(Dataset<Row> toWriteOrig, Arguments args, JavaSparkContext ctx, Pipe... pipes) throws ZinggClientException {
+		try {
 			for (Pipe p: pipes) {
 			Dataset<Row> toWrite = toWriteOrig;
 			DataFrameWriter writer = toWrite.write();
@@ -280,11 +281,13 @@ public class PipeUtil {
 			}
 			
 			
+			}
+		} catch (Exception ex) {
+			throw new ZinggClientException(ex.getMessage());
 		}
-
 	}
 
-	public static void writePerSource(Dataset<Row> toWrite, Arguments args, JavaSparkContext ctx, Pipe[] pipes ) {
+	public static void writePerSource(Dataset<Row> toWrite, Arguments args, JavaSparkContext ctx, Pipe[] pipes ) throws ZinggClientException {
 		List<Row> sources = toWrite.select(ColName.SOURCE_COL).distinct().collectAsList();
 		for (Row r : sources) {
 			Dataset<Row> toWriteNow = toWrite.filter(toWrite.col(ColName.SOURCE_COL).equalTo(r.get(0)));


### PR DESCRIPTION
The branch for this issue has been taken from navinrathaore/zingg-1/**zProperErrors**. This branch has work for  "Exception handling in PipeUtil::read() #229"
As current work is also somewhat related to same files. The current PR can be viewed after the PR #229.

**Details of changes**

* In both read() and write(), the Pipe.getProps() has been referred to. The check for nullity is needed in both set of places.
* As for fix the issue, it has been chosen to initialize the object with Empty Map object [Pipe.java]. It will just avoid the check of nullity.
* Still, if any mandatory property is needed but if it is missing, spark may throw an exception. e.g.
  in write() for csv type, if location is missing. following error comes with no zingg exception handling.
```
java.lang.IllegalArgumentException: Expected exactly one path to be specified, but got: 
	at org.apache.spark.sql.execution.datasources.DataSource.planForWritingFileFormat(DataSource.scala:474)
	at org.apache.spark.sql.execution.datasources.DataSource.planForWriting(DataSource.scala:572)
	at org.apache.spark.sql.DataFrameWriter.saveToV1Source(DataFrameWriter.scala:438)
	at org.apache.spark.sql.DataFrameWriter.saveInternal(DataFrameWriter.scala:415)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:301)
	at zingg.util.PipeUtil.write(PipeUtil.java:279)
```
* In read(), as such there is no error but count of read record is ZERO (0)
* After the above changes the write() output looks like.
```
  2022-05-02 08:37:11,529 [main] WARN  zingg.util.PipeUtil - Writing output Pipe [name=output, format=CSV, preprocessors=null, props={}, schema=null]
 2022-05-02 08:37:13,422 [main] WARN  zingg.client.util.Email - Unable to send email Can't send command to SMTP host
 2022-05-02 08:37:13,422 [main] WARN  zingg.client.Client - Apologies for this message. Zingg has encountered an error. Expected exactly one path to be specified, but got: 
```
* In previous PR #229, exception handling block has been added in read(). If that is fine there, it could be fine with write() as well as it is done in the current fix.

In sort, the changes will avoid unwanted exceptions. There shall not be any functionality change.
